### PR TITLE
fix: remove unsafe-eval from CSP and fix query param injection in auth

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -102,7 +102,7 @@ const nextConfig = {
                         value: [
                             "default-src 'self'",
                             // unsafe-inline required for Next.js inline scripts/styles; replace with nonce-based CSP as next step
-                            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com",
+                            "script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com",
                             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
                             "img-src 'self' data: blob: https:",
                             "font-src 'self' data: https://fonts.gstatic.com",

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -55,7 +55,7 @@ export const doCompleteSignup = async (
 };
 
 export const verifyRegisterToken = async (registerToken: string): Promise<ApiResponse<VerifyTokenResponseDTO>> => {
-    const { data } = await axiosApi.get<ApiResponse<VerifyTokenResponseDTO>>(`/auth/register/verify-token?registerToken=${registerToken}`);
+    const { data } = await axiosApi.get<ApiResponse<VerifyTokenResponseDTO>>(`/auth/register/verify-token?registerToken=${encodeURIComponent(registerToken)}`);
     return data;
 };
 
@@ -84,4 +84,3 @@ export const resendVerificationEmail = async (email: string): Promise<ApiRespons
 export const doLogout = async (): Promise<void> => {
     await axiosApi.post("/auth/logout");
 };
-


### PR DESCRIPTION
1. CSP script-src included 'unsafe-eval' — this directive allows attackers to execute arbitrary JavaScript via eval(), Function(), setTimeout(string), etc., significantly weakening the Content Security Policy against XSS. Next.js does not require unsafe-eval in production. Removed it.

2. verifyRegisterToken used raw string interpolation to build the query string (`?registerToken=${registerToken}`). If the token contains characters like &, =, or #, this could inject additional query parameters or truncate the value. Changed to use encodeURIComponent for proper URL encoding.