### PR TITLE
ci: fix ERR_PNPM_IGNORED_BUILDS breaking all CI

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  '@sentry/cli': true
+  core-js: true
+  sharp: true
+  unrs-resolver: true

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -8,7 +8,11 @@ describe('utils', () => {
     });
 
     it('should handle conditional classes', () => {
-      expect(cn('foo', false && 'bar', 'baz')).toBe('foo baz');
+      // Typed as boolean rather than inlining `false` so the condition is not
+      // a constant expression (no-constant-binary-expression), while still
+      // exercising the falsy-argument path that cn() must drop.
+      const isActive: boolean = false;
+      expect(cn('foo', isActive && 'bar', 'baz')).toBe('foo baz');
     });
 
     it('should handle Tailwind conflicts', () => {


### PR DESCRIPTION
## Problem

Every CI run has failed at `pnpm install --frozen-lockfile` since ~1 July:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @sentry/cli@2.58.5,
  core-js@3.48.0, sharp@0.34.5, unrs-resolver@1.11.1
##[error]Process completed with exit code 1.
```

pnpm 10+ no longer runs dependency build scripts unless they are allowlisted.

## Root cause

`pnpm-workspace.yaml` with the correct `allowBuilds` block already existed in the repo — but **untracked**. Someone ran `pnpm approve-builds` locally and never committed the result, so CI never saw it.

## Impact

- Nothing has been lint/typecheck/test/build-gated on any PR for 5+ weeks.
- `sharp` must build for `next/image` optimization to work; without it, image optimization silently degrades.

## Verification

```
$ pnpm install --frozen-lockfile   # clean
$ node -e "require('sharp')"       # sharp OK
```

Unblocks Dependabot PRs #386, #387 and #388, which are red only because they inherit this failure.