### PR TITLE
chore(vercel): only main auto-deploys; previews become opt-in

### DIFF
--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Vercel "Ignored Build Step".
+#
+# POLICY
+#   - `main` (production)  -> always builds and deploys to app.alsonotify.com
+#   - every other branch   -> skipped by default, no automatic preview deploy
+#   - on demand            -> put [vercel deploy] anywhere in the commit message
+#
+# EXIT CODE SEMANTICS (Vercel's, and they are backwards from intuition):
+#   exit 0  -> SKIP the build
+#   exit 1  -> PROCEED with the build
+#
+# Vercel sets these for us:
+#   VERCEL_ENV                  production | preview | development
+#   VERCEL_GIT_COMMIT_REF       branch name
+#   VERCEL_GIT_COMMIT_MESSAGE   full commit message
+#
+# Output from this script appears in the Vercel build log, so every decision
+# below explains itself there.
+
+set -uo pipefail
+
+BRANCH="${VERCEL_GIT_COMMIT_REF:-unknown}"
+ENVIRONMENT="${VERCEL_ENV:-unknown}"
+MESSAGE="${VERCEL_GIT_COMMIT_MESSAGE:-}"
+
+echo "Vercel ignore-build check"
+echo "  branch:      ${BRANCH}"
+echo "  environment: ${ENVIRONMENT}"
+
+# 1. Production always builds. Never gate the main deploy behind anything
+#    clever — a broken ignore script must not be able to block production.
+if [ "${ENVIRONMENT}" = "production" ]; then
+  echo "  -> BUILD (production deploy)"
+  exit 1
+fi
+
+# 2. Explicit on-demand opt-in for any non-production branch.
+case "${MESSAGE}" in
+  *"[vercel deploy]"*)
+    echo "  -> BUILD ([vercel deploy] found in commit message)"
+    exit 1
+    ;;
+esac
+
+# 3. Everything else is skipped.
+echo "  -> SKIP (preview deploys are disabled by default)"
+echo ""
+echo "     To deploy this branch, either:"
+echo "       * include [vercel deploy] in the commit message, or"
+echo "       * run 'vercel deploy' from the Vercel CLI"
+exit 0

--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -37,9 +37,16 @@ if [ "${ENVIRONMENT}" = "production" ]; then
 fi
 
 # 2. Explicit on-demand opt-in for any non-production branch.
-case "${MESSAGE}" in
+#
+#    Only the SUBJECT (first line) is searched, not the whole message. The
+#    first version scanned the entire body and promptly matched the commit
+#    that documented this very feature — writing "[vercel deploy]" in prose
+#    triggered a deploy. Restricting to the subject keeps the token usable in
+#    documentation, comments and PR descriptions without side effects.
+SUBJECT="$(printf '%s\n' "${MESSAGE}" | head -n 1)"
+case "${SUBJECT}" in
   *"[vercel deploy]"*)
-    echo "  -> BUILD ([vercel deploy] found in commit message)"
+    echo "  -> BUILD ([vercel deploy] found in commit subject)"
     exit 1
     ;;
 esac

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash scripts/vercel-ignore-build.sh"
+}


### PR DESCRIPTION
## What changes

Today every branch and PR triggers an automatic Vercel preview deployment. This adds a [Vercel Ignored Build Step](https://vercel.com/docs/projects/overview#ignored-build-step) so:

| Branch | Behaviour |
|---|---|
| `main` (production) | Always builds → `app.alsonotify.com` |
| Any other branch | **Skipped** — no automatic preview |
| Any branch, on demand | Builds if the commit message contains `[vercel deploy]`, or via `vercel deploy` from the CLI |

## Why in-repo rather than the dashboard

`vercel.json` + a script keeps the policy version-controlled, reviewable in a PR, and travelling with the branch. A dashboard setting is invisible from the code and easy to change without a trace.

## Safety

Production is checked **first and unconditionally**:

```bash
if [ "${ENVIRONMENT}" = "production" ]; then
  echo "  -> BUILD (production deploy)"
  exit 1
fi
```

A bug anywhere later in the script cannot block a production deploy.

> Vercel's exit codes are counterintuitive: **exit 0 skips** the build, **exit 1 proceeds**. The script documents this at the top.

## Verified locally

| Scenario | Exit | Result |
|---|---|---|
| production / main | 1 | BUILD |
| preview / feature branch | 0 | SKIP |
| preview + `[vercel deploy]` | 1 | BUILD |
| preview / dependabot branch | 0 | SKIP |
| production / empty message | 1 | BUILD |

## Note on this PR

This PR's own Vercel check should report **skipped** — it is the first branch subject to its own rule, which doubles as the live test.