### PR TITLE
fix(security): untrack .env.sentry-build-plugin (rotation still required)

### DIFF
--- a/.env.sentry-build-plugin
+++ b/.env.sentry-build-plugin
@@ -1,5 +1,0 @@
-# DO NOT commit this file to your repository!
-# The SENTRY_AUTH_TOKEN variable is picked up by the Sentry Build Plugin.
-# It's used for authentication when uploading source maps.
-# You can also set this env variable in your own `.env` files and remove this file.
-SENTRY_AUTH_TOKEN=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

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,11 @@ refactor_report.md
 *.zip
 
 # Sentry Config File
+# Sentry build-plugin token — MUST NEVER be tracked.
+# Was committed 3x before (0d5640b, 07c5443, bd2aa77) and kept returning:
+# a .gitignore entry does nothing for an already-tracked file, so those
+# "removal" commits never actually untracked it. Untracked for real in #393.
+# CI/CD should read SENTRY_AUTH_TOKEN from GitHub Actions / Vercel env vars.
 .env.sentry-build-plugin
 
 # This project uses pnpm exclusively (see pnpm-lock.yaml).


### PR DESCRIPTION
## Problem

A **live** Sentry auth token is committed at HEAD:

```bash
$ git show HEAD:.env.sentry-build-plugin | grep -c 'sntrys_'
1
```

Three earlier commits tried to fix this — `0d5640b`, `07c5443`, `bd2aa77`, all titled some variant of "remove committed Sentry auth token". None worked, because the file was tracked **and** listed in `.gitignore`. A gitignore entry is a no-op for an already-tracked file, so it kept coming back.

## Verified safe

The real risk was breaking production sourcemap upload. Tested empirically with the file absent:

```
[@sentry/nextjs] Warning: No auth token provided. Will not create release.
[@sentry/nextjs] Warning: No auth token provided. Will not upload source maps.
build exit=0
```

The build **succeeds**. Worst case is that sourcemaps stop uploading until `SENTRY_AUTH_TOKEN` is set as a Vercel environment variable — degraded observability, not a broken deploy. That's strictly better than leaving a live credential at HEAD.

CI does not reference the token at all (`grep SENTRY .github/workflows/ci.yml` → nothing).

## ⚠️ Still required — cannot be done from a PR

1. **Rotate the token** at https://sentry.io/settings/fynix-digital/auth-tokens/ — revoke the one starting `sntrys_eyJpYXQi`, issue a replacement scoped to `project:releases` + `org:read`.
2. **Add `SENTRY_AUTH_TOKEN`** to Vercel project env vars so sourcemap upload resumes.
3. **Optionally purge history** with `git filter-repo`. Lower priority once the token is dead, and it requires coordinating a force-push.

Untracking removes the token from HEAD. It remains in history and has already been exposed to everyone with repo access — **rotation is the step that actually revokes it.**