### PR TITLE
feat(security): Phase 3 auth hardening — frontend

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,66 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+/**
+ * Server-side route guard.
+ *
+ * SCOPE: this checks that the `_token` httpOnly cookie is PRESENT. It does not
+ * verify the signature — that would require the JWT secret in the edge runtime,
+ * duplicating the trust boundary. The backend remains the authoritative gate on
+ * every API call.
+ *
+ * What this buys us: unauthenticated visitors stop receiving protected page
+ * shells and their JavaScript, and authenticated users stop seeing the
+ * momentary flash of a protected layout before the client-side redirect fires.
+ */
+
+const AUTH_COOKIE = '_token';
+
+/** Routes reachable without a session. */
+const PUBLIC_ROUTES = [
+  '/login',
+  '/register',
+  '/forgot-password',
+  '/password-reset',
+];
+
+/** Routes an authenticated user should be bounced away from. */
+const AUTH_ONLY_ROUTES = ['/login', '/register'];
+
+function isPublic(pathname: string): boolean {
+  // Exact match, or a path segment beneath it. Deliberately NOT startsWith on
+  // the bare string: that would make "/loginsomething" public.
+  return PUBLIC_ROUTES.some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`),
+  );
+}
+
+export function middleware(request: NextRequest): NextResponse {
+  const { pathname, search } = request.nextUrl;
+  const hasSession = Boolean(request.cookies.get(AUTH_COOKIE)?.value);
+
+  // Signed in but sitting on login/register — send them into the app.
+  if (hasSession && AUTH_ONLY_ROUTES.includes(pathname)) {
+    return NextResponse.redirect(new URL('/dashboard', request.url));
+  }
+
+  if (isPublic(pathname)) {
+    return NextResponse.next();
+  }
+
+  if (!hasSession) {
+    const loginUrl = new URL('/login', request.url);
+    // Round-trip the intended destination. safeRedirectPath() validates it
+    // again on the way out, so a crafted value cannot become an open redirect.
+    loginUrl.searchParams.set('redirect', `${pathname}${search}`);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  // Everything except Next internals, static assets and the Sentry tunnel.
+  matcher: [
+    '/((?!api|_next/static|_next/image|favicon.ico|monitoring|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)',
+  ],
+};

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -5,5 +5,6 @@ Sentry.init({
   environment: process.env.NODE_ENV,
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
   enableLogs: true,
-  sendDefaultPii: true,
+  // Was true: sent user email, IP and headers with every event.
+  sendDefaultPii: false,
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -5,5 +5,6 @@ Sentry.init({
   environment: process.env.NODE_ENV,
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
   enableLogs: true,
-  sendDefaultPii: true,
+  // Was true: sent user email, IP and headers with every event.
+  sendDefaultPii: false,
 });

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -6,6 +6,7 @@ import { getUserDetails } from "../services/user";
 import { UpgradeOrgDto } from "@/types/dto/user.dto";
 import { queryKeys } from "../lib/queryKeys";
 import { useUserDetails } from "./useUser";
+import { safeRedirectPath } from '@/utils/security/redirect';
 
 export const useLogin = () => {
   const router = useRouter();
@@ -21,8 +22,8 @@ export const useLogin = () => {
           queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
         }
 
-        const redirect = variables.redirect || "/dashboard";
-        router.push(redirect);
+        // Never push an unvalidated query param — that is an open redirect.
+        router.push(safeRedirectPath(variables.redirect));
       }
     },
   });

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -3,12 +3,22 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NODE_ENV,
-  integrations: [Sentry.replayIntegration()],
+  integrations: [
+    Sentry.replayIntegration({
+      // Replay previously captured the raw DOM on every error, so password
+      // reset and invoice forms were recorded verbatim. Mask by default.
+      maskAllText: true,
+      maskAllInputs: true,
+      blockAllMedia: true,
+    }),
+  ],
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
   enableLogs: true,
-  replaysSessionSampleRate: 0.1,
-  replaysOnErrorSampleRate: 1.0,
-  sendDefaultPii: true,
+  replaysSessionSampleRate: 0.05,
+  // Was 1.0 — every single error produced a full session recording.
+  replaysOnErrorSampleRate: 0.1,
+  // Was true: sent user email, IP and headers with every event.
+  sendDefaultPii: false,
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/src/tests/middleware.test.ts
+++ b/src/tests/middleware.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { NextRequest } from 'next/server';
+import { middleware } from '../../middleware';
+
+/**
+ * Route protection was entirely client-side, so protected page shells and
+ * their JavaScript were served to unauthenticated requests; only the
+ * subsequent API calls failed.
+ */
+const makeRequest = (path: string, cookie?: string) =>
+  new NextRequest(new URL(`https://app.alsonotify.com${path}`), {
+    headers: cookie ? { cookie } : {},
+  });
+
+const SESSION = '_token=abc.def.ghi';
+
+describe('auth middleware', () => {
+  it('redirects an unauthenticated request to /dashboard', () => {
+    const res = middleware(makeRequest('/dashboard'));
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toContain('/login');
+  });
+
+  it('preserves the original path as a redirect param', () => {
+    const res = middleware(makeRequest('/dashboard/tasks'));
+    expect(res.headers.get('location')).toContain(
+      `redirect=${encodeURIComponent('/dashboard/tasks')}`,
+    );
+  });
+
+  it('preserves the query string on the original path', () => {
+    const res = middleware(makeRequest('/dashboard/partners?invite=abc'));
+    expect(res.headers.get('location')).toContain(
+      encodeURIComponent('/dashboard/partners?invite=abc'),
+    );
+  });
+
+  it('allows an authenticated request through', () => {
+    expect(middleware(makeRequest('/dashboard', SESSION)).status).toBe(200);
+  });
+
+  it('allows unauthenticated access to /login', () => {
+    expect(middleware(makeRequest('/login')).status).toBe(200);
+  });
+
+  it('sends an authenticated user away from /login', () => {
+    const res = middleware(makeRequest('/login', SESSION));
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toContain('/dashboard');
+  });
+
+  it('allows unauthenticated access to the password reset flow', () => {
+    expect(middleware(makeRequest('/forgot-password')).status).toBe(200);
+    expect(middleware(makeRequest('/password-reset/abc123')).status).toBe(200);
+  });
+
+  it('allows unauthenticated access to /register', () => {
+    expect(middleware(makeRequest('/register')).status).toBe(200);
+  });
+
+  it('does not treat a prefix collision as public', () => {
+    // "/loginsomething" must not be matched by the "/login" public rule.
+    const res = middleware(makeRequest('/loginsomething'));
+    expect(res.status).toBe(307);
+  });
+});

--- a/src/utils/security/redirect.test.ts
+++ b/src/utils/security/redirect.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { safeRedirectPath } from './redirect';
+
+/**
+ * `?redirect=` was read from the query string and handed straight to
+ * router.push(), so /login?redirect=https://evil.example sent a freshly
+ * authenticated user off-origin.
+ */
+describe('safeRedirectPath', () => {
+  it('allows an ordinary internal path', () => {
+    expect(safeRedirectPath('/dashboard/tasks')).toBe('/dashboard/tasks');
+  });
+
+  it('preserves query strings on internal paths', () => {
+    expect(safeRedirectPath('/dashboard/partners?invite=abc')).toBe(
+      '/dashboard/partners?invite=abc',
+    );
+  });
+
+  it('rejects an absolute external URL', () => {
+    expect(safeRedirectPath('https://evil.example/phish')).toBe('/dashboard');
+    expect(safeRedirectPath('http://evil.example')).toBe('/dashboard');
+  });
+
+  it('rejects a protocol-relative URL', () => {
+    expect(safeRedirectPath('//evil.example/phish')).toBe('/dashboard');
+  });
+
+  it('rejects backslash-obfuscated protocol-relative URLs', () => {
+    expect(safeRedirectPath('/\\evil.example')).toBe('/dashboard');
+    expect(safeRedirectPath('\\\\evil.example')).toBe('/dashboard');
+  });
+
+  it('rejects javascript: and data: URLs', () => {
+    expect(safeRedirectPath('javascript:alert(1)')).toBe('/dashboard');
+    expect(safeRedirectPath('data:text/html,<script>alert(1)</script>')).toBe('/dashboard');
+  });
+
+  it('rejects percent-encoded bypasses', () => {
+    // Decoded first, so %2F%2F is caught by the same rule as //.
+    expect(safeRedirectPath('%2F%2Fevil.example')).toBe('/dashboard');
+  });
+
+  it('rejects malformed percent-encoding rather than throwing', () => {
+    expect(safeRedirectPath('%E0%A4%A')).toBe('/dashboard');
+  });
+
+  it('rejects values containing control characters', () => {
+    expect(safeRedirectPath('/dashboard\nSet-Cookie: x=y')).toBe('/dashboard');
+  });
+
+  it('falls back for null, undefined and empty input', () => {
+    expect(safeRedirectPath(null)).toBe('/dashboard');
+    expect(safeRedirectPath(undefined)).toBe('/dashboard');
+    expect(safeRedirectPath('')).toBe('/dashboard');
+    expect(safeRedirectPath('   ')).toBe('/dashboard');
+  });
+
+  it('honours a custom fallback', () => {
+    expect(safeRedirectPath('https://evil.example', '/login')).toBe('/login');
+  });
+});

--- a/src/utils/security/redirect.ts
+++ b/src/utils/security/redirect.ts
@@ -1,0 +1,42 @@
+const DEFAULT_REDIRECT = '/dashboard';
+
+// C0 and C1 control characters. A newline here could split a header or smuggle
+// a second directive into a URL.
+// eslint-disable-next-line no-control-regex -- deliberate: matching control chars is the point
+const CONTROL_CHARS = /[\u0000-\u001F\u007F-\u009F]/;
+
+/**
+ * Reduce an untrusted `?redirect=` value to a safe same-origin path.
+ *
+ * Anything that could leave this origin returns the fallback. We ALLOWLIST the
+ * shape we want — exactly one leading slash followed by a character that is
+ * neither a slash nor a backslash — rather than blocklisting known-bad
+ * prefixes. Blocklists lose to encoding tricks; this shape check rejects
+ * "//evil.com", "/\evil.com", "\\evil.com" and every absolute URL scheme
+ * ("https:", "javascript:", "data:") in one rule, because none of them begin
+ * with a single slash.
+ */
+export function safeRedirectPath(
+  candidate: string | null | undefined,
+  fallback: string = DEFAULT_REDIRECT,
+): string {
+  if (!candidate) return fallback;
+
+  // Decode first so percent-encoded bypasses (%2F%2Fevil.com) are caught by the
+  // same rules as their literal form. Malformed encoding is rejected outright.
+  let value: string;
+  try {
+    value = decodeURIComponent(candidate);
+  } catch {
+    return fallback;
+  }
+
+  value = value.trim();
+  if (value === '') return fallback;
+
+  if (CONTROL_CHARS.test(value)) return fallback;
+
+  if (!/^\/[^/\\]/.test(value)) return fallback;
+
+  return value;
+}


### PR DESCRIPTION
Phase 3 frontend.

## Open redirect

`?redirect=` was read from the query string and handed straight to `router.push()`, so `/login?redirect=https://evil.example` sent a freshly authenticated user off-origin.

`safeRedirectPath()` **allowlists** the shape we want — exactly one leading slash followed by a non-slash, non-backslash character — rather than blocklisting bad prefixes, which lose to encoding tricks. It decodes first, so `%2F%2F` is caught by the same rule as `//`. One check rejects `//evil`, `/\evil`, `\\evil` and every absolute scheme (`https:`, `javascript:`, `data:`).

## Server-side route guard

Route protection was **entirely client-side**, so protected page shells and their JavaScript were served to unauthenticated requests; only the follow-up API calls failed.

`middleware.ts` checks for the `_token` cookie at the edge. It deliberately does **not** verify the signature — that would put the JWT secret in the edge runtime and duplicate the trust boundary. The backend stays the real gate; this stops shells leaking and removes the authenticated-flash on load.

Verified at runtime against a production build, not just unit tests:

| Request | Result |
|---|---|
| `/dashboard` no cookie | 307 → `/login?redirect=%2Fdashboard` |
| `/dashboard` with `_token` | 200 |
| `/login` no cookie | 200 |
| `/login` with `_token` | 307 → `/dashboard` |
| `/forgot-password` | 200 |
| `/favicon.ico` | not redirected (matcher excludes assets) |

Also confirmed the compiled `middleware-manifest.json` contains the matcher — Next 16 renames the concept to "Proxy", so I checked rather than assumed.

## Sentry

`sendDefaultPii: true` on client, server **and** edge. Session replay ran at `replaysOnErrorSampleRate: 1.0` with no masking, recording password-reset and invoice form input verbatim. Now `maskAllText` / `maskAllInputs` / `blockAllMedia`, sampled at 0.1.

## Verification

```
lint       0 errors (27 pre-existing warnings, all in *.test.ts)
typecheck  clean
tests      643 passed (62 files, up from 623)
build      clean
```